### PR TITLE
Feature/use pre align results

### DIFF
--- a/src/lib/align/aligners/multi_contig_aligner.rs
+++ b/src/lib/align/aligners/multi_contig_aligner.rs
@@ -5,7 +5,7 @@ use crate::align::aligners::constants::DEFAULT_ALIGNER_CAPACITY;
 use crate::align::aligners::single_contig_aligner::SingleContigAligner;
 use crate::align::alignment::Alignment;
 use crate::align::scoring::Scoring;
-use crate::align::traceback::traceback;
+use crate::align::traceback::{traceback, traceback_all};
 use bio::alignment::pairwise::MatchFunc;
 use bio::utils::TextSlice;
 use itertools::Itertools;
@@ -348,6 +348,27 @@ impl<'a, F: MatchFunc> MultiContigAligner<'a, F> {
             .map(|contig| &contig.aligner)
             .collect_vec();
         traceback(&aligners, n)
+    }
+
+    pub fn traceback_all(
+        &mut self,
+        n: usize,
+        contig_indexes: Option<&HashSet<usize>>,
+    ) -> Vec<Alignment> {
+        let aligners: Vec<&SingleContigAligner<_>> = match contig_indexes {
+            Some(indexes) if indexes.len() < self.len() => self
+                .contigs
+                .iter()
+                .filter(|contig| indexes.contains(&(contig.aligner.contig_idx as usize)))
+                .map(|c| &c.aligner)
+                .collect(),
+            _ => self
+                .contigs
+                .iter()
+                .map(|contig| &contig.aligner)
+                .collect_vec(),
+        };
+        traceback_all(&aligners, n)
     }
 }
 

--- a/src/lib/align/io.rs
+++ b/src/lib/align/io.rs
@@ -41,7 +41,7 @@ pub struct InputMessage {
 /// 2. None if no alignment was found, otherwise some tuple of pairwise alignment and the target
 ///   strand to which the alignment was made.
 /// 3. The alignment score, if aligned.
-pub type OutputResult = (FastqOwnedRecord, Option<Alignment>, Option<i32>);
+pub type OutputResult = (FastqOwnedRecord, Vec<Alignment>, Option<i32>);
 
 /// The container for a chunk of pairwise alignments, one per input FASTQ record.
 pub struct OutputMessage {


### PR DESCRIPTION
1.  Uses pre-alignment results to subset the contigs to which we aligb.  Also improve re-alignment around the origin.
2.  Opt-in to filter out secondary alignments based on score.  Also optimize when to correct across origin alignments when attempting a single-contig alignment.
3. Only re-align single contigs when original would be re-aligned.
4. Can print out sub-optimal alignments

