### PR TITLE
fix: suboptimal alignments could lead to panics during traceback

### DIFF
--- a/src/lib/align/aligners/multi_contig_aligner.rs
+++ b/src/lib/align/aligners/multi_contig_aligner.rs
@@ -355,20 +355,16 @@ impl<'a, F: MatchFunc> MultiContigAligner<'a, F> {
         n: usize,
         contig_indexes: Option<&HashSet<usize>>,
     ) -> Vec<Alignment> {
-        let aligners: Vec<&SingleContigAligner<_>> = match contig_indexes {
-            Some(indexes) if indexes.len() < self.len() => self
-                .contigs
-                .iter()
-                .filter(|contig| indexes.contains(&(contig.aligner.contig_idx as usize)))
-                .map(|c| &c.aligner)
-                .collect(),
+        let contig_indexes_to_consider: HashSet<usize> = match contig_indexes {
+            Some(indexes) if indexes.len() < self.len() => indexes.clone(),
             _ => self
                 .contigs
                 .iter()
-                .map(|contig| &contig.aligner)
-                .collect_vec(),
+                .map(|contig| contig.aligner.contig_idx as usize)
+                .collect::<HashSet<_>>(),
         };
-        traceback_all(&aligners, n)
+        let aligners = self.contigs.iter().map(|c| &c.aligner).collect_vec();
+        traceback_all(&aligners, n, &contig_indexes_to_consider)
     }
 }
 


### PR DESCRIPTION
In the case that the sub-optimal alignment jumps back to a contig that should not be considered.