### PR TITLE
Fix parsing of CLI enum values

### DIFF
--- a/fqcv-cli/src/commands/align.rs
+++ b/fqcv-cli/src/commands/align.rs
@@ -452,3 +452,16 @@ impl Command for Align {
         Align::execute(self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::Align;
+
+    /// Check that the argument parser works
+    #[test]
+    fn test_parse() {
+        Align::parse_from(["align", "-f", ".", "-r", "."]);
+    }
+}


### PR DESCRIPTION
Adds the necessary call on `PossibleValuesParser`s to map the selected value to the correct enum variant.