### PR TITLE
Support input reads as FASTA

### DIFF
--- a/fg-stitch-lib/src/align/aligners/mod.rs
+++ b/fg-stitch-lib/src/align/aligners/mod.rs
@@ -661,7 +661,7 @@ impl<'a, F: MatchFunc> SamRecordFormatter<'a, F> {
                 *record.data_mut() = data;
             }
 
-            return Ok([record].to_vec());
+            return Ok(vec![record]);
         }
 
         let mut records = Vec::new();
@@ -735,7 +735,7 @@ impl<'a, F: MatchFunc> SamRecordFormatter<'a, F> {
                 *record.flags_mut() = new_flags;
 
                 let (bases_vec, quals_vec, cigar) = match (is_forward, hard_clip && is_secondary) {
-                    (true, false) => (bases.to_vec(), quals.to_owned(), sub.cigar.clone()),
+                    (true, false) => (bases.to_owned(), quals.to_owned(), sub.cigar.clone()),
                     (true, true) => (
                         bases[sub.query_start..sub.query_end].to_vec(),
                         quals

--- a/fg-stitch-lib/src/align/aligners/mod.rs
+++ b/fg-stitch-lib/src/align/aligners/mod.rs
@@ -22,6 +22,7 @@ use crate::{
             multi_contig_aligner::MultiContigAligner,
         },
         alignment::Alignment,
+        io::FastxOwnedRecord,
         scoring::Scoring,
         sub_alignment::SubAlignmentBuilder,
         PrimaryPickingStrategy,
@@ -39,7 +40,6 @@ use bio::alignment::{
 };
 use bit_set::BitSet;
 use constants::DEFAULT_ALIGNER_CAPACITY;
-use itertools::Itertools;
 use noodles::{
     core::Position,
     sam::{
@@ -51,7 +51,6 @@ use noodles::{
         },
     },
 };
-use seq_io::fastq::{OwnedRecord as FastqOwnedRecord, Record as FastqRecord};
 
 #[derive(Default, Debug, PartialEq, Eq, Copy, Clone)]
 pub struct JumpInfo {
@@ -236,15 +235,11 @@ pub struct Aligners<'a, F: MatchFunc> {
 impl Aligners<'_, MatchParams> {
     pub fn align(
         &mut self,
-        record: &FastqOwnedRecord,
+        record: &FastxOwnedRecord,
         target_seqs: &[TargetSeq],
         target_hashes: &[TargetHash],
     ) -> (Vec<Alignment>, Option<i32>) {
-        let query = record
-            .seq()
-            .iter()
-            .map(u8::to_ascii_uppercase)
-            .collect_vec();
+        let query = record.seq_upper_case();
         let mut contig_idx_to_prealign_score: IndexMap<i32> =
             IndexMap::new(self.multi_contig.len());
         if self.opts.pre_align {
@@ -625,7 +620,7 @@ fn header_to_name(header: &[u8]) -> Result<String> {
 impl<'a, F: MatchFunc> SamRecordFormatter<'a, F> {
     pub fn format(
         &self,
-        fastq: &FastqOwnedRecord,
+        fastq: &FastxOwnedRecord,
         alignments: &[Alignment],
         alt_score: Option<i32>,
     ) -> Result<Vec<SamRecord>> {
@@ -644,10 +639,12 @@ impl<'a, F: MatchFunc> SamRecordFormatter<'a, F> {
             *record.flags_mut() = Flags::UNMAPPED;
 
             // bases
-            *record.sequence_mut() = Sequence::try_from(bases.to_vec()).unwrap();
+            *record.sequence_mut() = Sequence::try_from(bases.to_owned()).unwrap();
 
             // qualities
-            *record.quality_scores_mut() = QualityScores::try_from(quals.to_vec()).unwrap();
+            if let Some(quals) = quals {
+                *record.quality_scores_mut() = QualityScores::try_from(quals.to_owned()).unwrap();
+            }
 
             // cigar
             *record.cigar_mut() = Cigar::default();
@@ -738,26 +735,32 @@ impl<'a, F: MatchFunc> SamRecordFormatter<'a, F> {
                 *record.flags_mut() = new_flags;
 
                 let (bases_vec, quals_vec, cigar) = match (is_forward, hard_clip && is_secondary) {
-                    (true, false) => (bases.to_vec(), quals.to_vec(), sub.cigar.clone()),
+                    (true, false) => (bases.to_vec(), quals.to_owned(), sub.cigar.clone()),
                     (true, true) => (
                         bases[sub.query_start..sub.query_end].to_vec(),
-                        quals[sub.query_start..sub.query_end].to_vec(),
+                        quals
+                            .as_ref()
+                            .map(|quals| quals[sub.query_start..sub.query_end].to_vec()),
                         Cigar::try_from(sub.cigar.iter().rev().copied().collect::<Vec<Op>>())
                             .unwrap(),
                     ),
                     (false, false) => (
                         reverse_complement(bases),
-                        quals.iter().copied().rev().collect(),
+                        quals
+                            .as_ref()
+                            .map(|quals| quals.iter().copied().rev().collect()),
                         Cigar::try_from(sub.cigar.iter().rev().copied().collect::<Vec<Op>>())
                             .unwrap(),
                     ),
                     (false, true) => (
                         reverse_complement(bases[sub.query_start..sub.query_end].to_vec()),
-                        quals[sub.query_start..sub.query_end]
-                            .iter()
-                            .copied()
-                            .rev()
-                            .collect(),
+                        quals.as_ref().map(|quals| {
+                            quals[sub.query_start..sub.query_end]
+                                .iter()
+                                .copied()
+                                .rev()
+                                .collect()
+                        }),
                         Cigar::try_from(sub.cigar.iter().rev().copied().collect::<Vec<Op>>())
                             .unwrap(),
                     ),
@@ -767,7 +770,9 @@ impl<'a, F: MatchFunc> SamRecordFormatter<'a, F> {
                 *record.sequence_mut() = Sequence::try_from(bases_vec).unwrap();
 
                 // qualities
-                *record.quality_scores_mut() = QualityScores::try_from(quals_vec).unwrap();
+                if let Some(quals) = quals_vec {
+                    *record.quality_scores_mut() = QualityScores::try_from(quals).unwrap();
+                }
 
                 // cigar
                 let clip_op = if hard_clip && is_secondary {
@@ -877,18 +882,20 @@ impl<'a, F: MatchFunc> SamRecordFormatter<'a, F> {
 #[cfg(test)]
 pub mod tests {
     use super::Builder;
-    use crate::util::target_seq::{self, TargetHash};
-    use seq_io::fastq::OwnedRecord as FastqOwnedRecord;
+    use crate::{
+        align::io::FastxOwnedRecord,
+        util::target_seq::{self, TargetHash},
+    };
 
     #[test]
     fn test_case_insensitive() {
         let seq = b"ACGGACAGATCGAATACGACAGGAC".to_vec();
         let target_seqs = [target_seq::TargetSeq::new("test-contig", &seq, false)];
         let mut aligners = Builder::default().build_aligners(&target_seqs);
-        let record = FastqOwnedRecord {
+        let record = FastxOwnedRecord {
             head: b"test-record".to_vec(),
             seq: seq.clone(),
-            qual: vec![b'#'; seq.len()],
+            qual: Some(vec![b'#'; seq.len()]),
         };
         let k = 7;
         let target_hashes: Vec<TargetHash> = target_seqs

--- a/fg-stitch-lib/src/align/io.rs
+++ b/fg-stitch-lib/src/align/io.rs
@@ -1,12 +1,18 @@
 use super::alignment::Alignment;
 use crate::util::io::{is_fastq_path, is_gzip_path};
 use anyhow::{Context, Result};
+use derive_getters::Getters;
 use flate2::bufread::MultiGzDecoder;
 use flume::{bounded, Receiver, Sender};
-use seq_io::fastq::{OwnedRecord as FastqOwnedRecord, Reader as FastqReader};
+use itertools::Itertools;
+use seq_io::{
+    fasta::{Reader as FastaReader, RefRecord as FastaRefRecord},
+    fastq::{Reader as FastqReader, RefRecord as FastqRefRecord},
+};
 use std::{
     fs::File,
     io::{BufReader, Read},
+    iter::Peekable,
     path::PathBuf,
     thread::JoinHandle,
 };
@@ -20,12 +26,78 @@ pub const RECORDS_PER_CHUNK_PER_THREAD: usize = 10;
 /// The number of chunks allowed in a channel
 pub const READER_CHANNEL_NUM_CHUNKS: usize = 100;
 
+/// Enumeration of supported input file formats
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub enum Format {
+    #[default]
+    FASTQ,
+    FASTA,
+}
+
+#[derive(Clone, Debug, Getters)]
+/// Common record struct that supports both FASTA and FASTQ
+pub struct FastxOwnedRecord {
+    pub head: Vec<u8>,
+    pub seq: Vec<u8>,
+    pub qual: Option<Vec<u8>>,
+}
+
+impl FastxOwnedRecord {
+    pub fn from_fastq(record: &FastqRefRecord) -> Self {
+        let owned_record = record.to_owned_record();
+        Self {
+            head: owned_record.head,
+            seq: owned_record.seq,
+            qual: Some(owned_record.qual),
+        }
+    }
+
+    pub fn from_fasta(record: &FastaRefRecord) -> Self {
+        let owned_record = record.to_owned_record();
+        Self {
+            head: owned_record.head,
+            seq: owned_record.seq,
+            qual: None,
+        }
+    }
+
+    pub fn seq_upper_case(&self) -> Vec<u8> {
+        self.seq.iter().map(u8::to_ascii_uppercase).collect_vec()
+    }
+}
+
+pub struct FastaToFastxIterator(FastaReader<Box<dyn Read>>);
+
+impl Iterator for FastaToFastxIterator {
+    type Item = FastxOwnedRecord;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0
+            .next()
+            .map(|record| record.expect("Error reading fasta record"))
+            .map(|record| FastxOwnedRecord::from_fasta(&record))
+    }
+}
+
+pub struct FastqToFastxIterator(FastqReader<Box<dyn Read>>);
+
+impl Iterator for FastqToFastxIterator {
+    type Item = FastxOwnedRecord;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0
+            .next()
+            .map(|record| record.expect("Error reading fasta record"))
+            .map(|record| FastxOwnedRecord::from_fastq(&record))
+    }
+}
+
 /// A message that is sent from a [`FastqThreadReader`] to the aligner threadpool to align a chunk
 /// of FASTQ records.
 #[derive(Debug)]
 pub struct InputMessage {
     /// The FASTQ records to align
-    pub records: Vec<FastqOwnedRecord>,
+    pub records: Vec<FastxOwnedRecord>,
 
     /// Where the records will be sent after alignment
     pub oneshot: Sender<OutputMessage>,
@@ -36,44 +108,34 @@ pub struct InputMessage {
 /// 2. None if no alignment was found, otherwise some tuple of pairwise alignment and the target
 ///   strand to which the alignment was made.
 /// 3. The alignment score, if aligned.
-pub type OutputResult = (FastqOwnedRecord, Vec<Alignment>, Option<i32>);
+pub type OutputResult = (FastxOwnedRecord, Vec<Alignment>, Option<i32>);
 
 /// The container for a chunk of pairwise alignments, one per input FASTQ record.
 pub struct OutputMessage {
     pub results: Vec<OutputResult>,
 }
 
-pub struct FastqGroupingIterator<I: Iterator<Item = FastqOwnedRecord>> {
-    pub record: Option<FastqOwnedRecord>,
-    pub iter: I,
-}
+pub struct FastxGroupingIterator<I: Iterator<Item = FastxOwnedRecord>>(Peekable<I>);
 
-impl<I: Iterator<Item = FastqOwnedRecord>> FastqGroupingIterator<I> {
+impl<I: Iterator<Item = FastxOwnedRecord>> FastxGroupingIterator<I> {
     pub fn new(iter: I) -> Self {
-        Self { record: None, iter }
+        Self(iter.peekable())
     }
 }
 
-impl<I: Iterator<Item = FastqOwnedRecord>> Iterator for FastqGroupingIterator<I> {
-    type Item = Vec<FastqOwnedRecord>;
+impl<I: Iterator<Item = FastxOwnedRecord>> Iterator for FastxGroupingIterator<I> {
+    type Item = Vec<FastxOwnedRecord>;
 
     #[inline]
-    fn next(&mut self) -> Option<Vec<FastqOwnedRecord>> {
-        if self.record.is_none() {
-            self.record = self.iter.next();
-        }
-        match self.record {
+    fn next(&mut self) -> Option<Vec<FastxOwnedRecord>> {
+        match self.0.next() {
             None => None,
-            Some(ref record) => {
-                let mut items: Vec<FastqOwnedRecord> = Vec::new();
-                let sequence = record.seq.clone();
-                items.push(record.clone());
-                self.record = None;
-                for record in &mut self.iter {
-                    if record.seq == sequence {
-                        items.push(record);
+            Some(record) => {
+                let mut items: Vec<FastxOwnedRecord> = vec![record];
+                while let Some(record) = self.0.peek() {
+                    if record.seq == items[0].seq {
+                        items.push(self.0.next().expect("Expected record"));
                     } else {
-                        self.record = Some(record);
                         break;
                     }
                 }
@@ -84,7 +146,7 @@ impl<I: Iterator<Item = FastqOwnedRecord>> Iterator for FastqGroupingIterator<I>
 }
 
 /// A FASTQ reader that runs in its own thread and chunks reads to send to a pool of aligners.
-pub struct FastqThreadReader {
+pub struct FastxThreadReader {
     /// The [`JoinHandle`] for the thread that is reading.
     pub handle: JoinHandle<Result<()>>,
     /// The channel that will be receiving [`AlignmentsMessage`]s.
@@ -93,17 +155,17 @@ pub struct FastqThreadReader {
     pub to_output_rx: Receiver<Receiver<OutputMessage>>,
 }
 
-impl FastqThreadReader {
+impl FastxThreadReader {
     /// Writes the chunk of records to the alignment channel, as well as a receiver to the output
     /// channel.
     fn write_records_to_txs(
-        records: &[FastqOwnedRecord],
+        records: Vec<FastxOwnedRecord>,
         to_align_tx: &Sender<InputMessage>,
         to_output_tx: &Sender<Receiver<OutputMessage>>,
     ) {
         let (records_tx, records_rx) = flume::unbounded(); // oneshot channel
         let input_msg = InputMessage {
-            records: records.to_vec(),
+            records,
             oneshot: records_tx,
         };
         to_align_tx.send(input_msg).expect("Error sending message");
@@ -113,7 +175,7 @@ impl FastqThreadReader {
     }
 
     /// Creates a new `FastqThreadReader` in a new thread.
-    pub fn new(file: PathBuf, decompress: bool, threads: usize) -> Self {
+    pub fn new(file: PathBuf, format: Format, decompress: bool, threads: usize) -> Self {
         // Channel to send chunks of records to align
         let (to_align_tx, to_align_rx): (Sender<InputMessage>, Receiver<InputMessage>) =
             bounded(READER_CHANNEL_NUM_CHUNKS * threads);
@@ -147,23 +209,30 @@ impl FastqThreadReader {
                 }
             };
 
-            // Open a FASTQ reader, then group reads that have the same read sequence, then chunk
-            // chunk the reads to send over the output channel, keeping reads with the same read
-            // sequence grouped together.
-            let fastq_iter = FastqReader::with_capacity(maybe_decoder_handle, GZ_BUFSIZE)
-                .into_records()
-                .map(|r| r.expect("Error reading"));
-            let fastq_grouping_iter = FastqGroupingIterator::new(fastq_iter);
-            let mut records = Vec::new();
+            // Open an input file reader, group reads that have the same read sequence, then chunk
+            // the reads to send over the output channel, keeping reads with the same read sequence
+            // grouped together.
+            let fastq_iter: Box<dyn Iterator<Item = FastxOwnedRecord>> = match format {
+                Format::FASTQ => Box::new(FastqToFastxIterator(FastqReader::with_capacity(
+                    maybe_decoder_handle,
+                    GZ_BUFSIZE,
+                ))),
+                Format::FASTA => Box::new(FastaToFastxIterator(FastaReader::with_capacity(
+                    maybe_decoder_handle,
+                    GZ_BUFSIZE,
+                ))),
+            };
+            let fastq_grouping_iter = FastxGroupingIterator::new(fastq_iter);
+            let mut records = Vec::with_capacity(RECORDS_PER_CHUNK_PER_THREAD);
             for chunk in fastq_grouping_iter {
                 records.extend(chunk);
                 if records.len() >= RECORDS_PER_CHUNK_PER_THREAD {
-                    Self::write_records_to_txs(&records, &to_align_tx, &to_output_tx);
-                    records.clear();
+                    Self::write_records_to_txs(records, &to_align_tx, &to_output_tx);
+                    records = Vec::with_capacity(RECORDS_PER_CHUNK_PER_THREAD);
                 }
             }
             if !records.is_empty() {
-                Self::write_records_to_txs(&records, &to_align_tx, &to_output_tx);
+                Self::write_records_to_txs(records, &to_align_tx, &to_output_tx);
             }
 
             Ok(())


### PR DESCRIPTION
It's generally a good idea to support FASTA input, especially for long reads, and especially when quality scores are not required. For example, I downloaded the Simpson 2023 data from SRA in FASTA format to save time/space.

This PR introduces the `align::io::FastxOwnedRecord` class, which is similar to `FastqOwnedRecord` except that `qual` is optional. `FastxOwnedRecord` can be created from `FastaRefRecord` or `FastqRefRecord`. There are also adapter iterators.

I use an `ArgGroup` to specify that exactly one of the `--reads_fastq` or `--reads_fastq` options is required.

A few other cleanups and minor improvements, such as using `peekable()` for a cleaner implementation of the grouping iterator.