### PR TITLE
feat: update output SAM flags and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Chimeric reads may span large inter- or intra-contig distances, and thus present
 Potential use cases include, but are not limited to:
 
 1. Aligning vectors/plasmids/viruses (assemblies, long reads, etc) to a database of constructs to determine the component structure
-2. Determining the structure of complex structural variants (e.g., chromthripsis, cccDNA, etc.)
+2. Determining the structure of complex structural variants (e.g., chromothripsis, cccDNA, etc.)
 3. Per-read evidence for somatic fusions and other structural variants
 
 ## Installing
@@ -132,7 +132,7 @@ The SAM tags are set as follows:
 | `qe` | `i` | the zero-based exclusive index of the last query base in the sub-alignment |
 | `ts` | `i` |  the zero-based index of the first target base in the sub-alignment |
 | `te` | `i` |  the zero-based exclusive index of the last target base in the sub-alignment |
-| `as` | `i` |  the alignment score of the chain (not the sub-alignmnet, see `AS` for that) |
+| `as` | `i` |  the alignment score of the chain (not the sub-alignment, see `AS` for that) |
 | `xs` | `i` |  the sub-optimal alignment score, practically the maximum of any pre-alignment and secondary chain |
 | `si` | `i` |  the index of the sub-alignment in the current chain |
 | `sc` | `Z` |  the cigar of the given sub-alignment, without any soft or hard clipping |
@@ -143,17 +143,15 @@ The SAM tags are set as follows:
 | `SA` | `Z` |  the semicolon-delimited list of alignments for the given chain (rname, pos, strand, CIGAR, mapQ, NM) |
 | `NM` | `i` | the number of edits in the sub-alignment |
 
-### Optional pre-alignment
-
 The `-p`/`--pre-alignment` option may be used to pre-align the read using banded local alignment to select only those reads with a minimum pre-alignment score to perform the full alignment.
-Additional options are availabe to control the k-mer size, band-width, and minimum alignment score for this step.
+Additional options are available to control the k-mer size, band-width, and minimum alignment score for this step.
 Furthermore, the full alignment can be limited to align the read to just those reference contigs with minimum alignment score with the `-x`/`--pre-align-subset-contigs`.
 This is useful when aligning to a large database of individual constructs as contigs, where the read is expected only to align to a small subset of the contigs.
 
 ### Alignment Scoring
 
 Alignments are scored using a match score, mismatch penalty, and affine gap penalty (a gap of size `k` costs `{-O} + {-E}*k`).
-Scores must be positive while penalities must be negative.
+Scores must be positive while penalties must be negative.
 
 The jump score can be specified with `--jump-score`.
 
@@ -162,7 +160,7 @@ The jump score may also be specified specific to the jump being within
 - the same contig but opposite strand (`--jump-score-same-contig-opposite-strand`), and
 - the across different contigs (`--jump-score-inter-contig`).
 
-If any of these options are not specified, then they will default to the the value specified by `--jump-score`.
+If any of these options are not specified, then they will default to the value specified by `--jump-score`.
 
 ### Alignment mode
 

--- a/fg-stitch-lib/src/align/aligners/mod.rs
+++ b/fg-stitch-lib/src/align/aligners/mod.rs
@@ -51,7 +51,7 @@ use noodles::{
         alignment::Record as SamRecord,
         record::{
             cigar::op::{Kind, Op},
-            data::field::tag::ALIGNMENT_SCORE,
+            data::field::tag::{ALIGNMENT_SCORE, EDIT_DISTANCE, OTHER_ALIGNMENTS},
             Cigar, Data, Flags, MappingQuality, QualityScores, ReadName as SamReadName, Sequence,
         },
     },
@@ -673,7 +673,7 @@ impl<'a, F: MatchFunc> SamRecordFormatter<'a, F> {
         // NB: please see the main README.md for the description of the custom SAM tags
         let mut records = Vec::new();
 
-        // The alignment score for the representative aligment in the primary chain, used to filter
+        // The alignment score for the representative alignment in the primary chain, used to filter
         // secondary alignments from the output
         let mut primary_alignment_score = MIN_SCORE;
 
@@ -683,18 +683,17 @@ impl<'a, F: MatchFunc> SamRecordFormatter<'a, F> {
             let suboptimal_chain_score = chains.iter().skip(1).map(|a| a.score).max();
             match (suboptimal_chain_score, pre_alignment_score) {
                 (None, None) => None,
-                (None, Some(score)) => Some(score),
-                (Some(score), None) => Some(score),
+                (None, Some(score)) | (Some(score), None) => Some(score),
                 (Some(score), Some(alt_score)) => Some(score.max(alt_score)),
             }
         };
 
         // Examine each alignment (chain of sub-alignments).  This assumes chains are sorted
-        // desecending by score
+        // descending by score
         for (chain_idx, chain) in chains.iter().enumerate() {
             let hard_clip = !self.opts.soft_clip;
 
-            // Get the sub-aligments for this chain
+            // Get the sub-alignments for this chain
             let mut builder: SubAlignmentBuilder = SubAlignmentBuilder::new(self.opts.use_eq_and_x);
             let mut subs = builder.build(chain, true, &self.scoring);
             ensure!(!subs.is_empty());
@@ -746,6 +745,13 @@ impl<'a, F: MatchFunc> SamRecordFormatter<'a, F> {
                 );
                 subs = new_subs;
             }
+
+            // The SAM records for this chain
+            let mut chain_records = Vec::new();
+
+            // Gather the SA string for each sub-alignment so we can later rotate the list to have
+            // the primary alignment at the start
+            let mut sa_strings: Vec<String> = Vec::new();
 
             // Iterate through each sub-alignment in this chain, creating one SAM record per
             for (sub_idx, sub) in subs.iter().enumerate() {
@@ -843,26 +849,30 @@ impl<'a, F: MatchFunc> SamRecordFormatter<'a, F> {
                 if clip_suffix_len > 0 {
                     cigar_ops.push(Op::new(clip_op, clip_suffix_len));
                 }
-                *record.cigar_mut() = Cigar::try_from(cigar_ops).unwrap();
+                let cigar = Cigar::try_from(cigar_ops).unwrap();
+                let cigar_string = cigar.to_string();
+                *record.cigar_mut() = cigar;
 
                 // target id
-                *record.reference_sequence_id_mut() = Some(sub.contig_idx % self.target_seqs.len());
+                let reference_sequence_id = sub.contig_idx % self.target_seqs.len();
+                *record.reference_sequence_id_mut() = Some(reference_sequence_id);
 
                 // target start
-                if is_forward {
-                    *record.alignment_start_mut() = Position::new(sub.target_start + 1);
+                let reference_start = if is_forward {
+                    sub.target_start + 1
                 } else {
                     let target_len =
                         self.target_seqs[sub.contig_idx % self.target_seqs.len()].len();
-                    *record.alignment_start_mut() = Position::new(target_len - sub.target_end + 1);
-                }
+                    target_len - sub.target_end + 1
+                };
+                *record.alignment_start_mut() = Position::new(reference_start);
 
                 // mapping quality
                 // TODO: base this on the suboptimal_score
                 let mapq = if chain_idx == 0 { 60 } else { 0 };
                 *record.mapping_quality_mut() = MappingQuality::new(mapq);
 
-                // TODO: tags (e.g. XS, NM, MD)
+                // TODO: tags (e.g. XS, MD)
                 let mut data = Data::default();
                 data.insert(
                     QUERY_START.parse().unwrap(),
@@ -918,8 +928,47 @@ impl<'a, F: MatchFunc> SamRecordFormatter<'a, F> {
                     ALIGNMENT_SCORE,
                     noodles::sam::record::data::field::Value::from(sub.score),
                 );
+                data.insert(
+                    EDIT_DISTANCE,
+                    noodles::sam::record::data::field::Value::from(sub.num_edits),
+                );
                 *record.data_mut() = data;
 
+                chain_records.push(record);
+
+                // Build the SA string: `rname,pos,strand,CIGAR,mapQ,NM;`
+                let mut sa_string = String::with_capacity(128);
+                // rname
+                sa_string.push_str(&self.target_seqs[reference_sequence_id].name);
+                // pos
+                sa_string.push_str(&format!(",{reference_start},"));
+                // strand
+                sa_string.push_str(if is_forward { "+" } else { "-" });
+                // CIGAR
+                sa_string.push_str(&format!(",{cigar_string}"));
+                // mapQ
+                sa_string.push_str(&format!(",{mapq}"));
+                // NM
+                sa_string.push_str(&format!(",{}", sub.num_edits));
+                // Add it!
+                sa_strings.push(sa_string);
+            }
+
+            // Build the SA tag, then add to each record in this chain, and finally add it to the
+            // final vector of records.  Note: the SA strings must be rotated so the primary
+            // alignment is at the start
+            sa_strings.rotate_right(primary_sub_idx);
+            let sa_string = sa_strings.join(";");
+            for mut record in chain_records {
+                let data = record.data_mut();
+                data.insert(
+                    OTHER_ALIGNMENTS,
+                    noodles::sam::record::data::field::Value::from_str_type(
+                        &sa_string,
+                        noodles::sam::record::data::field::Type::String,
+                    )
+                    .unwrap(),
+                );
                 records.push(record);
             }
         }

--- a/fg-stitch-lib/src/align/aligners/mod.rs
+++ b/fg-stitch-lib/src/align/aligners/mod.rs
@@ -30,11 +30,7 @@ use crate::{
     util::{
         dna::reverse_complement,
         index_map::IndexMap,
-        tag::{
-            CHAIN_ALIGNMENT_SCORE, CHAIN_INDEX, CHAIN_LENGTH, NUMBER_OF_CHAINS, QUERY_END,
-            QUERY_START, SUBOPTIMAL_SCORE, SUB_ALIGNMENT_CIGAR, SUB_ALIGNMENT_INDEX, TARGET_END,
-            TARGET_START,
-        },
+        tag::CustomTag,
         target_seq::{TargetHash, TargetSeq},
     },
 };
@@ -875,37 +871,37 @@ impl<'a, F: MatchFunc> SamRecordFormatter<'a, F> {
                 // TODO: tags (e.g. XS, MD)
                 let mut data = Data::default();
                 data.insert(
-                    QUERY_START.parse().unwrap(),
+                    CustomTag::QueryStart.into(),
                     noodles::sam::record::data::field::Value::from(sub.query_start as u32),
                 );
                 data.insert(
-                    QUERY_END.parse().unwrap(),
+                    CustomTag::QueryStart.into(),
                     noodles::sam::record::data::field::Value::from(sub.query_end as u32),
                 );
                 data.insert(
-                    TARGET_START.parse().unwrap(),
+                    CustomTag::TargetStart.into(),
                     noodles::sam::record::data::field::Value::from(sub.target_start as u32),
                 );
                 data.insert(
-                    TARGET_END.parse().unwrap(),
+                    CustomTag::TargetEnd.into(),
                     noodles::sam::record::data::field::Value::from(sub.target_end as u32),
                 );
                 data.insert(
-                    CHAIN_ALIGNMENT_SCORE.parse().unwrap(),
+                    CustomTag::ChainAlignmentScore.into(),
                     noodles::sam::record::data::field::Value::from(chain.score),
                 );
                 if let Some(score) = suboptimal_score {
                     data.insert(
-                        SUBOPTIMAL_SCORE.parse().unwrap(),
+                        CustomTag::SuboptimalScore.into(),
                         noodles::sam::record::data::field::Value::from(score),
                     );
                 }
                 data.insert(
-                    SUB_ALIGNMENT_INDEX.parse().unwrap(),
+                    CustomTag::SubAlignmentIndex.into(),
                     noodles::sam::record::data::field::Value::from(sub_idx as i32),
                 );
                 data.insert(
-                    SUB_ALIGNMENT_CIGAR.parse().unwrap(),
+                    CustomTag::SubAlignmentCigar.into(),
                     noodles::sam::record::data::field::Value::from_str_type(
                         &cigar_str,
                         noodles::sam::record::data::field::Type::String,
@@ -913,15 +909,15 @@ impl<'a, F: MatchFunc> SamRecordFormatter<'a, F> {
                     .unwrap(),
                 );
                 data.insert(
-                    CHAIN_LENGTH.parse().unwrap(),
+                    CustomTag::ChainLength.into(),
                     noodles::sam::record::data::field::Value::from(subs.len() as i32),
                 );
                 data.insert(
-                    CHAIN_INDEX.parse().unwrap(),
+                    CustomTag::ChainIndex.into(),
                     noodles::sam::record::data::field::Value::from(chain_idx as i32),
                 );
                 data.insert(
-                    NUMBER_OF_CHAINS.parse().unwrap(),
+                    CustomTag::NumberOfChains.into(),
                     noodles::sam::record::data::field::Value::from(chains.len() as i32),
                 );
                 data.insert(

--- a/fg-stitch-lib/src/align/aligners/mod.rs
+++ b/fg-stitch-lib/src/align/aligners/mod.rs
@@ -925,6 +925,14 @@ impl<'a, F: MatchFunc> SamRecordFormatter<'a, F> {
                     noodles::sam::record::data::field::Value::from(chains.len() as i32),
                 );
                 data.insert(
+                    "cg".parse().unwrap(),
+                    noodles::sam::record::data::field::Value::from_str_type(
+                        &cigar_str,
+                        noodles::sam::record::data::field::Type::String,
+                    )
+                    .unwrap(),
+                );
+                data.insert(
                     ALIGNMENT_SCORE,
                     noodles::sam::record::data::field::Value::from(sub.score),
                 );

--- a/fg-stitch-lib/src/align/sub_alignment.rs
+++ b/fg-stitch-lib/src/align/sub_alignment.rs
@@ -161,23 +161,23 @@ impl SubAlignmentBuilder {
 
     pub fn build<F: MatchFunc>(
         &mut self,
-        alignment: &Alignment,
+        chain: &Alignment,
         swap: bool,
         scoring: &Scoring<F>,
     ) -> Vec<SubAlignment> {
         self.elements.clear();
-        self.query_start = alignment.xstart;
-        self.target_start = alignment.ystart;
+        self.query_start = chain.xstart;
+        self.target_start = chain.ystart;
         self.query_offset = self.query_start;
         self.target_offset = self.target_start;
         self.score = 0;
-        self.contig_idx = alignment.start_contig_idx;
+        self.contig_idx = chain.start_contig_idx;
 
         let mut alignments = Vec::new();
-        let mut last = alignment.operations[0];
+        let mut last = chain.operations[0];
         let mut op_len = 0;
-        for i in 0..alignment.operations.len() {
-            let op = alignment.operations[i];
+        for i in 0..chain.operations.len() {
+            let op = chain.operations[i];
             if self.cmp_op(last, op) {
                 op_len += 1;
             } else {

--- a/fg-stitch-lib/src/util/mod.rs
+++ b/fg-stitch-lib/src/util/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod dna;
 pub(crate) mod index_map;
 pub(crate) mod io;
+pub mod tag;
 pub mod target_seq;
 pub mod version;

--- a/fg-stitch-lib/src/util/tag.rs
+++ b/fg-stitch-lib/src/util/tag.rs
@@ -1,0 +1,34 @@
+//! Custom SAM tags for stitch.  See the README.md file for the description of each tag.
+
+/// (`qs`)
+pub const QUERY_START: &str = "qs";
+
+/// (`qe`)
+pub const QUERY_END: &str = "qe";
+
+/// (`ts`)
+pub const TARGET_START: &str = "ts";
+
+/// (`te`)
+pub const TARGET_END: &str = "te";
+
+/// (`as`)
+pub const CHAIN_ALIGNMENT_SCORE: &str = "as";
+
+/// (`xs`)
+pub const SUBOPTIMAL_SCORE: &str = "xs";
+
+/// (`si`)
+pub const SUB_ALIGNMENT_INDEX: &str = "si";
+
+/// (`sc`)
+pub const SUB_ALIGNMENT_CIGAR: &str = "sc";
+
+/// (`cl`)
+pub const CHAIN_LENGTH: &str = "cl";
+
+/// (`ci`)
+pub const CHAIN_INDEX: &str = "ci";
+
+/// (`cn`)
+pub const NUMBER_OF_CHAINS: &str = "cn";

--- a/fg-stitch-lib/src/util/tag.rs
+++ b/fg-stitch-lib/src/util/tag.rs
@@ -1,34 +1,52 @@
 //! Custom SAM tags for stitch.  See the README.md file for the description of each tag.
+use noodles::sam::record::data::field::Tag;
 
-/// (`qs`)
-pub const QUERY_START: &str = "qs";
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum CustomTag {
+    /// (`qs`)
+    QueryStart,
+    /// (`qe`)
+    QueryEnd,
+    /// (`ts`)
+    TargetStart,
+    /// (`te`)
+    TargetEnd,
+    /// (`as`)
+    ChainAlignmentScore,
+    /// (`xs`)
+    SuboptimalScore,
+    /// (`si`)
+    SubAlignmentIndex,
+    /// (`sc`)
+    SubAlignmentCigar,
+    /// (`cl`)
+    ChainLength,
+    /// (`ci`)
+    ChainIndex,
+    /// (`cn`)
+    NumberOfChains,
+}
 
-/// (`qe`)
-pub const QUERY_END: &str = "qe";
+impl AsRef<[u8]> for CustomTag {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            CustomTag::QueryStart => b"qs",
+            CustomTag::QueryEnd => b"qe",
+            CustomTag::TargetStart => b"ts",
+            CustomTag::TargetEnd => b"te",
+            CustomTag::ChainAlignmentScore => b"as",
+            CustomTag::SuboptimalScore => b"xs",
+            CustomTag::SubAlignmentIndex => b"si",
+            CustomTag::SubAlignmentCigar => b"sc",
+            CustomTag::ChainLength => b"cl",
+            CustomTag::ChainIndex => b"ci",
+            CustomTag::NumberOfChains => b"cn",
+        }
+    }
+}
 
-/// (`ts`)
-pub const TARGET_START: &str = "ts";
-
-/// (`te`)
-pub const TARGET_END: &str = "te";
-
-/// (`as`)
-pub const CHAIN_ALIGNMENT_SCORE: &str = "as";
-
-/// (`xs`)
-pub const SUBOPTIMAL_SCORE: &str = "xs";
-
-/// (`si`)
-pub const SUB_ALIGNMENT_INDEX: &str = "si";
-
-/// (`sc`)
-pub const SUB_ALIGNMENT_CIGAR: &str = "sc";
-
-/// (`cl`)
-pub const CHAIN_LENGTH: &str = "cl";
-
-/// (`ci`)
-pub const CHAIN_INDEX: &str = "ci";
-
-/// (`cn`)
-pub const NUMBER_OF_CHAINS: &str = "cn";
+impl From<CustomTag> for Tag {
+    fn from(value: CustomTag) -> Self {
+        value.as_ref().try_into().unwrap()
+    }
+}


### PR DESCRIPTION
This improves and standardizes how to identify to which linear alignment chain the SAM alignment belongs, the order of the alignments in a chain, and which chain is the "primary" chain.

Implements #44.