### PR TITLE
Updates to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Fulcrum Genomics LLC"]
 categories = ["science"]
+documentation = "https://github.com/fulcrumgenomics/stitch"
 edition = "2021"
 keywords = ["genomics", "bioinformatics", "sequencing", "alignment"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,12 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Fulcrum Genomics LLC"]
+categories = ["science"]
 edition = "2021"
+keywords = ["genomics", "bioinformatics", "sequencing", "alignment"]
 license = "MIT"
-repository = "https://github.com/fulcrumgenomics/fg-stitch"
+repository = "https://github.com/fulcrumgenomics/stitch"
+rust-version = "1.64"
 version = "0.1.0"
 
 [workspace.dependencies]

--- a/fg-stitch-cli/Cargo.toml
+++ b/fg-stitch-cli/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "4.2.7", features = ["derive", "string"] }
 enum_dispatch = "0.3.12"
 env_logger = "0.10.0"
 flume.workspace = true
-stitch = { version = "0.1.0", path = "../fg-stitch-lib", package = "fg-stitch-lib" }
+stitch = { path = "../fg-stitch-lib", package = "fg-stitch-lib" }
 itertools.workspace = true
 log = "0.4.17"
 noodles.workspace = true


### PR DESCRIPTION
* Set rust-version (#49)
* Fix repository URL (#50)
* Add category and keywords
* Drop version specifier from path dependencies as this is no longer required as of RFC 2906