### PR TITLE
Add enum class for custom tags, implement conversion to Tag

### DIFF
--- a/fg-stitch-lib/src/align/aligners/mod.rs
+++ b/fg-stitch-lib/src/align/aligners/mod.rs
@@ -30,11 +30,7 @@ use crate::{
     util::{
         dna::reverse_complement,
         index_map::IndexMap,
-        tag::{
-            CHAIN_ALIGNMENT_SCORE, CHAIN_INDEX, CHAIN_LENGTH, NUMBER_OF_CHAINS, QUERY_END,
-            QUERY_START, SUBOPTIMAL_SCORE, SUB_ALIGNMENT_CIGAR, SUB_ALIGNMENT_INDEX, TARGET_END,
-            TARGET_START,
-        },
+        tag::CustomTag,
         target_seq::{TargetHash, TargetSeq},
     },
 };
@@ -876,37 +872,37 @@ impl<'a, F: MatchFunc> SamRecordFormatter<'a, F> {
                 // TODO: tags (e.g. XS, MD)
                 let mut data = Data::default();
                 data.insert(
-                    QUERY_START.parse().unwrap(),
+                    CustomTag::QueryStart.into(),
                     noodles::sam::record::data::field::Value::from(sub.query_start as u32),
                 );
                 data.insert(
-                    QUERY_END.parse().unwrap(),
+                    CustomTag::QueryStart.into(),
                     noodles::sam::record::data::field::Value::from(sub.query_end as u32),
                 );
                 data.insert(
-                    TARGET_START.parse().unwrap(),
+                    CustomTag::TargetStart.into(),
                     noodles::sam::record::data::field::Value::from(sub.target_start as u32),
                 );
                 data.insert(
-                    TARGET_END.parse().unwrap(),
+                    CustomTag::TargetEnd.into(),
                     noodles::sam::record::data::field::Value::from(sub.target_end as u32),
                 );
                 data.insert(
-                    CHAIN_ALIGNMENT_SCORE.parse().unwrap(),
+                    CustomTag::ChainAlignmentScore.into(),
                     noodles::sam::record::data::field::Value::from(chain.score),
                 );
                 if let Some(score) = suboptimal_score {
                     data.insert(
-                        SUBOPTIMAL_SCORE.parse().unwrap(),
+                        CustomTag::SuboptimalScore.into(),
                         noodles::sam::record::data::field::Value::from(score),
                     );
                 }
                 data.insert(
-                    SUB_ALIGNMENT_INDEX.parse().unwrap(),
+                    CustomTag::SubAlignmentIndex.into(),
                     noodles::sam::record::data::field::Value::from(sub_idx as i32),
                 );
                 data.insert(
-                    SUB_ALIGNMENT_CIGAR.parse().unwrap(),
+                    CustomTag::SubAlignmentCigar.into(),
                     noodles::sam::record::data::field::Value::from_str_type(
                         &cigar_str,
                         noodles::sam::record::data::field::Type::String,
@@ -914,15 +910,15 @@ impl<'a, F: MatchFunc> SamRecordFormatter<'a, F> {
                     .unwrap(),
                 );
                 data.insert(
-                    CHAIN_LENGTH.parse().unwrap(),
+                    CustomTag::ChainLength.into(),
                     noodles::sam::record::data::field::Value::from(subs.len() as i32),
                 );
                 data.insert(
-                    CHAIN_INDEX.parse().unwrap(),
+                    CustomTag::ChainIndex.into(),
                     noodles::sam::record::data::field::Value::from(chain_idx as i32),
                 );
                 data.insert(
-                    NUMBER_OF_CHAINS.parse().unwrap(),
+                    CustomTag::NumberOfChains.into(),
                     noodles::sam::record::data::field::Value::from(chains.len() as i32),
                 );
                 data.insert(

--- a/fg-stitch-lib/src/util/tag.rs
+++ b/fg-stitch-lib/src/util/tag.rs
@@ -1,34 +1,52 @@
 //! Custom SAM tags for stitch.  See the README.md file for the description of each tag.
+use noodles::sam::record::data::field::Tag;
 
-/// (`qs`)
-pub const QUERY_START: &str = "qs";
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum CustomTag {
+    /// (`qs`)
+    QueryStart,
+    /// (`qe`)
+    QueryEnd,
+    /// (`ts`)
+    TargetStart,
+    /// (`te`)
+    TargetEnd,
+    /// (`as`)
+    ChainAlignmentScore,
+    /// (`xs`)
+    SuboptimalScore,
+    /// (`si`)
+    SubAlignmentIndex,
+    /// (`sc`)
+    SubAlignmentCigar,
+    /// (`cl`)
+    ChainLength,
+    /// (`ci`)
+    ChainIndex,
+    /// (`cn`)
+    NumberOfChains,
+}
 
-/// (`qe`)
-pub const QUERY_END: &str = "qe";
+impl AsRef<[u8]> for CustomTag {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            CustomTag::QueryStart => b"qs",
+            CustomTag::QueryEnd => b"qe",
+            CustomTag::TargetStart => b"ts",
+            CustomTag::TargetEnd => b"te",
+            CustomTag::ChainAlignmentScore => b"as",
+            CustomTag::SuboptimalScore => b"xs",
+            CustomTag::SubAlignmentIndex => b"si",
+            CustomTag::SubAlignmentCigar => b"sc",
+            CustomTag::ChainLength => b"cl",
+            CustomTag::ChainIndex => b"ci",
+            CustomTag::NumberOfChains => b"cn",
+        }
+    }
+}
 
-/// (`ts`)
-pub const TARGET_START: &str = "ts";
-
-/// (`te`)
-pub const TARGET_END: &str = "te";
-
-/// (`as`)
-pub const CHAIN_ALIGNMENT_SCORE: &str = "as";
-
-/// (`xs`)
-pub const SUBOPTIMAL_SCORE: &str = "xs";
-
-/// (`si`)
-pub const SUB_ALIGNMENT_INDEX: &str = "si";
-
-/// (`sc`)
-pub const SUB_ALIGNMENT_CIGAR: &str = "sc";
-
-/// (`cl`)
-pub const CHAIN_LENGTH: &str = "cl";
-
-/// (`ci`)
-pub const CHAIN_INDEX: &str = "ci";
-
-/// (`cn`)
-pub const NUMBER_OF_CHAINS: &str = "cn";
+impl From<CustomTag> for Tag {
+    fn from(value: CustomTag) -> Self {
+        value.as_ref().try_into().unwrap()
+    }
+}


### PR DESCRIPTION
Benefits:
* Avoid having to `use` a bunch of constants (although you could do `tag::CHAIN_ALIGNMENT_SCORE`, etc. instead)
* When a [`Tag::Other` `const` initializer is implemented](https://github.com/zaeleus/noodles/issues/204), you only need to change the implementation of `From` - public API stays the same.

Drawbacks:
* Deviates from how standard tags are implemented in noodles (as constants)

In any case, you'll get a minor performance bump from converting from bytes rather than strings.