### PR TITLE
Add version to fg-stitch-lib path dependency

### DIFF
--- a/fg-stitch-cli/Cargo.toml
+++ b/fg-stitch-cli/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "4.2.7", features = ["derive", "string"] }
 enum_dispatch = "0.3.12"
 env_logger = "0.10.0"
 flume.workspace = true
-stitch = { path = "../fg-stitch-lib", package = "fg-stitch-lib" }
+stitch = { path = "../fg-stitch-lib", package = "fg-stitch-lib", version = "0.1.2" }
 itertools.workspace = true
 log = "0.4.17"
 noodles.workspace = true


### PR DESCRIPTION
## Summary
- Adds `version = "0.1.2"` to the fg-stitch-lib path dependency in fg-stitch-cli/Cargo.toml
- Required for `cargo publish` — path dependencies must also specify a version for crates.io

The publish workflow successfully published fg-stitch-lib v0.1.2 but failed on fg-stitch because of this missing version field.

## Test plan
- [ ] CI passes
- [ ] After merge, publish workflow successfully publishes fg-stitch to crates.io